### PR TITLE
Fix: improve device detection for touch screen laptops with high-DPI displays

### DIFF
--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -367,6 +367,10 @@ export function createDeviceDetector() {
 				// Check for touch capability
 				const hasTouch = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
 
+				// Check for laptop-specific indicators
+				const hasMouseEvents = 'onmousemove' in window;
+				const hasKeyboard = 'onkeydown' in window;
+
 				// Check for mobile-specific browser features
 				const hasMobileUserAgent =
 					/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
@@ -377,9 +381,20 @@ export function createDeviceDetector() {
 				const smallScreen = window.screen.width < 768 || window.screen.height < 768;
 				const highPixelRatio = window.devicePixelRatio > 1.5;
 
-				// Determine if it's a mobile/tablet device
-				const isMobileOrTablet =
-					(hasTouch && hasMobileUserAgent) || (hasTouch && (smallScreen || highPixelRatio));
+				const isMobileOrTablet = (() => {
+					if (hasTouch && hasMobileUserAgent) {
+						return true; // Definitely mobile or tablet
+					} else if (hasTouch && (smallScreen || highPixelRatio)) {
+						// Additional checks for touchscreen laptops
+						if (hasMouseEvents && hasKeyboard) {
+							return false; // Likely a touchscreen laptop
+						} else {
+							return true; // Likely mobile or tablet
+						}
+					} else {
+						return false; // Likely not mobile or tablet
+					}
+				})();
 
 				set({
 					isDesktop: !isMobileOrTablet,


### PR DESCRIPTION
I was playing around with Haptic and was not happy with how scaled down the UI looks because of my ""fix"" in #14 

Decided to just do a PR and fix the issue

Tested on my laptop with the scenarios I listed in the issue and this PR solves the issue
Double checked on my phone to make sure it still blocks mobile as it should

Current Haptic running at 2880x1800 and 175% scale, 80% zoom in Chrome
![{B2B1F41B-C914-4C0C-9DFA-1AF120D071A3}](https://github.com/user-attachments/assets/b2b50a24-ff4c-47b9-99da-1f0ee9660882)

Haptic after the fix, same settings, just running at 100% zoom in Chrome
![{C93E5773-B3AD-4108-B4F2-6819967A477B}](https://github.com/user-attachments/assets/e7a6da12-0427-49b4-9448-02f202e4dcd5)

