### PR TITLE
#45 Provide a multiarch Docker image on Docker Hub 

### DIFF
--- a/.github/workflows/dockerize-on-release.yml
+++ b/.github/workflows/dockerize-on-release.yml
@@ -5,27 +5,47 @@ on:
     types: [published]
     branches: ['main']
 
+env:
+  DOCKER_PLATFORMS: |
+    linux/amd64
+    linux/arm64
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     steps:
-      - uses: actions/checkout@v3
-
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
+          install: true
+          platforms: ${{ env.DOCKER_PLATFORMS }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: chroxify/haptic-web
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
@@ -35,3 +55,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}


### PR DESCRIPTION
I wanted to have a local only version of haptic running on my mac but there was no arm64 image available! 

I'm curently building it locally but this PR updates the github workflow to build for both `linux/amd64` and `linux/arm64` #45. It should still send everything ok to docker hub but I don't have an account to test with. 

This is a screenshot of the build output showing the built for platforms

<img width="986" height="340" alt="image" src="https://github.com/user-attachments/assets/151807b8-b5f7-4701-98de-528a2ba79806" />


I also removed a duplicate checkout action and added `cancel-in-progress` which will cancel any previous instances of this action if a new one starts. 